### PR TITLE
Fix tx_count field parsing for Pepecoin compatibility

### DIFF
--- a/src/bin/tx-fingerprint-stats.rs
+++ b/src/bin/tx-fingerprint-stats.rs
@@ -45,7 +45,7 @@ fn main() {
     let chain = ChainQuery::new(Arc::clone(&store), Arc::clone(&daemon), &config, &metrics);
 
     let mut indexer = Indexer::open(Arc::clone(&store), FetchFrom::Bitcoind, &config, &metrics);
-    indexer.update(&daemon).unwrap();
+    indexer.update(&daemon, &chain).unwrap();
 
     let mut iter = store.txstore_db().raw_iterator();
     iter.seek(b"T");

--- a/src/new_index/schema.rs
+++ b/src/new_index/schema.rs
@@ -595,7 +595,7 @@ impl ChainQuery {
 
         if self.light_mode {
             let blockinfo = self.daemon.getblock_raw(hash, 1).ok()?;
-            Some(serde_json::from_value(blockinfo).unwrap())
+            Some(BlockMeta::parse_getblock(blockinfo).ok()?)
         } else {
             self.store
                 .txstore_db

--- a/src/util/block.rs
+++ b/src/util/block.rs
@@ -316,12 +316,22 @@ impl From<&BlockEntry> for BlockMeta {
 
 impl BlockMeta {
     pub fn parse_getblock(val: ::serde_json::Value) -> Result<BlockMeta> {
+        // Calculate tx_count from tx array length, fallback to nTx if available
+        let tx_count = if let Some(tx_array) = val.get("tx") {
+            if let Some(tx_vec) = tx_array.as_array() {
+                tx_vec.len() as u32
+            } else {
+                return Err("tx field is not an array".into());
+            }
+        } else if let Some(n_tx) = val.get("nTx") {
+            n_tx.as_f64()
+                .chain_err(|| "nTx not a number")? as u32
+        } else {
+            return Err("missing both tx array and nTx field".into());
+        };
+
         Ok(BlockMeta {
-            tx_count: val
-                .get("nTx")
-                .chain_err(|| "missing nTx")?
-                .as_f64()
-                .chain_err(|| "nTx not a number")? as u32,
+            tx_count,
             size: val
                 .get("size")
                 .chain_err(|| "missing size")?


### PR DESCRIPTION
## Problem
The electrs server was crashing with panic `"missing field 'tx_count'"` when processing block data from Pepecoin daemon, causing 502 Bad Gateway errors on block detail endpoints.

## Root Cause
- Pepecoin daemon's `getblock` RPC doesn't include the `nTx` field in its JSON response
- The `BlockMeta::parse_getblock()` method was expecting this field to exist
- Direct JSON deserialization in `schema.rs` was bypassing proper field mapping

## Solution
- Modified `BlockMeta::parse_getblock()` to calculate `tx_count` from the `tx` array length
- Added fallback to `nTx` field if available (for Bitcoin compatibility)
- Fixed `schema.rs` to use proper `BlockMeta` parsing instead of direct deserialization
- Fixed `tx-fingerprint-stats` binary compilation error

## Changes
- `src/util/block.rs`: Enhanced `parse_getblock()` method
- `src/new_index/schema.rs`: Use proper parsing method
- `src/bin/tx-fingerprint-stats.rs`: Fix method signature

## Testing
✅ All block endpoints now work correctly
✅ No more 502 Bad Gateway errors
✅ Proper JSON responses with transaction counts
✅ Backward compatible with Bitcoin daemons that include `nTx` field

## Files Changed
- 3 files changed, 17 insertions(+), 7 deletions(-)